### PR TITLE
Update Dockerfile to install GCS Adapter

### DIFF
--- a/5/debian/Dockerfile
+++ b/5/debian/Dockerfile
@@ -123,5 +123,9 @@ VOLUME $GHOST_CONTENT
 COPY docker-entrypoint.sh /usr/local/bin
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+RUN cd "$GHOST_INSTALL"; \
+	npm install ghost-gcp-storage-adapter; \
+	cp -r node_modules/ghost-gcp-storage-adapter versions/5.94.0/core/server/adapters/storage/ghost-gcp-storage-adapter;
+
 EXPOSE 2368
 CMD ["node", "current/index.js"]

--- a/5/debian/Dockerfile
+++ b/5/debian/Dockerfile
@@ -124,8 +124,12 @@ COPY docker-entrypoint.sh /usr/local/bin
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 RUN cd "$GHOST_INSTALL"; \
-	npm install ghost-gcp-storage-adapter; \
-	cp -r node_modules/ghost-gcp-storage-adapter versions/5.94.0/core/server/adapters/storage/ghost-gcp-storage-adapter;
+	apt-get update && apt-get install -y git; \
+	# installs our forked storage adapter that allows for uploads to buckets with uniform access
+	npm install git+https://github.com/SZNS/ghost-gcp-storage-adapter.git; \
+	cp -r node_modules/ghost-gcp-storage-adapter versions/5.94.0/core/server/adapters/storage/ghost-gcp-storage-adapter; \
+	# cleans cached package list files
+	rm -rf /var/lib/apt/lists/*;
 
 EXPOSE 2368
 CMD ["node", "current/index.js"]

--- a/5/debian/Dockerfile
+++ b/5/debian/Dockerfile
@@ -124,12 +124,9 @@ COPY docker-entrypoint.sh /usr/local/bin
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 RUN cd "$GHOST_INSTALL"; \
-	apt-get update && apt-get install -y git; \
-	# installs our forked storage adapter that allows for uploads to buckets with uniform access
-	npm install git+https://github.com/SZNS/ghost-gcp-storage-adapter.git; \
-	cp -r node_modules/ghost-gcp-storage-adapter versions/5.94.0/core/server/adapters/storage/ghost-gcp-storage-adapter; \
-	# cleans cached package list files
-	rm -rf /var/lib/apt/lists/*;
+	# Installs GCS adapter
+	npm install @danmasta/ghost-gcs-adapter; \
+	cp -r node_modules/@danmasta/ghost-gcs-adapter versions/5.94.0/core/server/adapters/storage/gcs;
 
 EXPOSE 2368
 CMD ["node", "current/index.js"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# https://github.com/docker-library/ghost
+# This is a FORK of the Ghost Docker Image at https://github.com/docker-library/ghost
+Steps were added to the Debian Dockerfile in order to install the [GCS Adapter](https://github.com/danmasta/ghost-gcs-adapter) as part of building the Ghost container image.
+
+# Below information is from the original source repository:
 
 ## Maintained by: [the Docker Community](https://github.com/docker-library/ghost)
 


### PR DESCRIPTION
# Description

Updated Ghost Dockerfile to install GCS Adapter in build steps


# Testing
- Docker image was successfully built from the Dockerfile using the command `docker build --platform linux/amd64 -t ghost-new-gcs-adapter .`
- Docker image was pushed to Google Artifact Registry `docker push gcr.io/szns-dev-ghost-hosting/ghost-new-gcs-adapter`
- Ghost Blog Cloud Run service was re-deployed with updated docker image
- Updated/Modified image assets are saved to Google Cloud Storage
<img width="1396" alt="image" src="https://github.com/user-attachments/assets/1412b847-83bf-4600-a02b-12f5a67ef8af">
